### PR TITLE
Improved fan speed control and windows defender handling

### DIFF
--- a/src/MinerClient/App.xaml.cs
+++ b/src/MinerClient/App.xaml.cs
@@ -136,7 +136,7 @@ namespace NTMiner {
                             NTMiner.Windows.WAU.DisableWAUAsync();
                         }
                         if (minerProfile.IsDisableAntiSpyware) {
-                            NTMiner.Windows.Defender.DisableAntiSpyware();
+                            NTMiner.Windows.Defender.DisableAntiSpyware(HomePath.HomeDirFullName, TempPath.TempDirFullName);
                         }
                         NTMiner.Windows.Crash.SetAutoReboot(minerProfile.IsAutoReboot);
                         if (!Firewall.IsMinerClientRuleExists()) {

--- a/src/NTMinerClient/Gpus/Impl/TempGruarder.cs
+++ b/src/NTMinerClient/Gpus/Impl/TempGruarder.cs
@@ -9,85 +9,86 @@ namespace NTMiner.Gpus.Impl {
         private TempGruarder() { }
 
         private bool _isInited = false;
-        // 记录显卡的上一次温度
-        private readonly Dictionary<int, int> _preTempDic = new Dictionary<int, int>();
-        // 记录显卡温度抵达防御温度的时间
-        private readonly Dictionary<int, DateTime> _fightedOnDic = new Dictionary<int, DateTime>();
-        private readonly int _fanSpeedDownSeconds = 20;
-        private readonly uint _fanSpeedDownStep = 2;
         private static readonly int _guardTemp = 60;
-        public void Init(INTMinerContext root) {
-            if (_isInited) {
+        private static readonly double _signinicant = 2;
+        // delta time is 1 second for Per1SecondEvent
+        private static readonly double _dt = 1;
+        private static readonly double _kp = 3;
+        private static readonly double _ti = 5;
+        private static readonly double _td = 0.05;
+        private readonly Dictionary<int, double> _preError1 = new Dictionary<int, double>();
+        private readonly Dictionary<int, double> _preError2 = new Dictionary<int, double>();
+        private readonly Dictionary<int, double> _lastOutput = new Dictionary<int, double>();
+        public void Init(INTMinerContext root)
+        {
+            if (_isInited)
+            {
                 return;
             }
             _isInited = true;
-            VirtualRoot.BuildEventPath<GpuStateChangedEvent>("当显卡温度变更时守卫温度防线", LogEnum.None,
-                path: message => {
-                    IGpu gpu = message.Source;
-                    if (gpu.Index == NTMinerContext.GpuAllId || root.MinerProfile.CoinId == Guid.Empty) {
-                        return;
-                    }
-                    IGpuProfile gpuProfile;
-                    if (NTMinerContext.Instance.GpuProfileSet.IsOverClockGpuAll(root.MinerProfile.CoinId)) {
-                        gpuProfile = NTMinerContext.Instance.GpuProfileSet.GetGpuProfile(root.MinerProfile.CoinId, NTMinerContext.GpuAllId);
-                    }
-                    else {
-                        gpuProfile = NTMinerContext.Instance.GpuProfileSet.GetGpuProfile(root.MinerProfile.CoinId, gpu.Index);
-                    }
-                    if (!gpuProfile.IsAutoFanSpeed) {
-                        return;
-                    }
-                    // 显卡温度抵达防御温度的时间
-                    if (!_fightedOnDic.TryGetValue(gpu.Index, out DateTime fightedOn)) {
-                        fightedOn = DateTime.Now;
-                        _fightedOnDic.Add(gpu.Index, fightedOn);
-                    }
-                    if (gpu.FanSpeed == 100 && gpu.Temperature > _guardTemp) {
-                        NTMinerConsole.DevDebug(() => $"GPU{gpu.Index.ToString()} 温度{gpu.Temperature.ToString()}大于防线温度{_guardTemp.ToString()}，但风扇转速已达100%");
-                    }
-                    else if (gpu.Temperature < _guardTemp) {
-                        if (!_preTempDic.ContainsKey(gpu.Index)) {
-                            _preTempDic.Add(gpu.Index, 0);
+            VirtualRoot.BuildEventPath<Per1SecondEvent>("周期性调节风扇转速守卫温度防线", LogEnum.None,
+                path: message =>
+                {
+                    double ki = _ti > 0 ? _dt / _ti : _dt;
+                    double kd = _td / _dt;
+                    foreach (var gpu in root.GpuSet.AsEnumerable())
+                    {
+                        if (!_preError1.ContainsKey(gpu.Index))
+                        {
+                            _preError1.Add(gpu.Index, 0);
                         }
-                        // 如果当前温度比上次的温度大
-                        if (gpu.Temperature > _preTempDic[gpu.Index]) {
-                            fightedOn = DateTime.Now;
-                            _fightedOnDic[gpu.Index] = fightedOn;
+                        if (!_preError2.ContainsKey(gpu.Index))
+                        {
+                            _preError2.Add(gpu.Index, 0);
                         }
-                        _preTempDic[gpu.Index] = gpu.Temperature;
-                        // 如果距离抵达防御温度的时间已经很久了则降速风扇
-                        if (fightedOn.AddSeconds(_fanSpeedDownSeconds) < DateTime.Now) {
-                            int cool = (int)(gpu.FanSpeed - _fanSpeedDownStep);
-                            // 如果温度低于50度则直接将风扇设为驱动默认的最小转速
-                            if (gpu.Temperature < 50) {
-                                cool = gpu.CoolMin;
-                            }
-                            if (cool >= gpu.CoolMin) {
-                                _fightedOnDic[gpu.Index] = DateTime.Now;
-                                root.GpuSet.OverClock.SetFanSpeed(gpu.Index, cool);
-                                NTMinerConsole.DevDebug(() => $"GPU{gpu.Index.ToString()} 风扇转速由{gpu.FanSpeed.ToString()}%调低至{cool.ToString()}%");
-                            }
+                        if (!_lastOutput.ContainsKey(gpu.Index))
+                        {
+                            _lastOutput.Add(gpu.Index, 0);
                         }
-                    }
-                    else if (gpu.Temperature > _guardTemp) {
-                        uint cool;
-                        uint len;
-                        // 防线突破可能是由于小量降低风扇转速造成的
-                        if (fightedOn.AddSeconds(_fanSpeedDownSeconds) < DateTime.Now) {
-                            _fightedOnDic[gpu.Index] = DateTime.Now;
-                            len = 100 - gpu.FanSpeed;
+                        IGpuProfile gpuProfile;
+                        if (NTMinerContext.Instance.GpuProfileSet.IsOverClockGpuAll(root.MinerProfile.CoinId))
+                        {
+                            gpuProfile = NTMinerContext.Instance.GpuProfileSet.GetGpuProfile(root.MinerProfile.CoinId, NTMinerContext.GpuAllId);
                         }
-                        else {
-                            len = _fanSpeedDownStep;
+                        else
+                        {
+                            gpuProfile = NTMinerContext.Instance.GpuProfileSet.GetGpuProfile(root.MinerProfile.CoinId, gpu.Index);
                         }
-                        cool = gpu.FanSpeed + (uint)Math.Ceiling(len / 2.0);
-                        if (cool > 100) {
-                            cool = 100;
+                        if (
+                            !gpuProfile.IsAutoFanSpeed
+                            || !NTMinerContext.Instance.IsMining
+                            || !NTMinerContext.Instance.GpuProfileSet.IsOverClockEnabled(root.LockedMineContext.MainCoin.GetId())
+                        )
+                        {
+                            _lastOutput[gpu.Index] = gpuProfile.Cool;
+                            _preError1[gpu.Index] = 0;
+                            _preError2[gpu.Index] = 0;
+                            continue;
                         }
-                        if (cool <= 100) {
-                            root.GpuSet.OverClock.SetFanSpeed(gpu.Index, (int)cool);
-                            NTMinerConsole.DevDebug(()=> $"GPU{gpu.Index.ToString()} 风扇转速由{gpu.FanSpeed.ToString()}%调高至{cool.ToString()}%");
+                        int error = _guardTemp - gpu.Temperature;
+                        double delta = _kp * (error - _preError1[gpu.Index]) + ki * error + kd * (error - 2 * _preError1[gpu.Index] + _preError2[gpu.Index]);
+                        _preError2[gpu.Index] = _preError1[gpu.Index];
+                        _preError1[gpu.Index] = error;
+
+                        double output = _lastOutput[gpu.Index] - delta;
+                        if (output > 100)
+                        {
+                            NTMinerConsole.DevDebug(() => $"GPU{gpu.Index.ToString()} 温度{gpu.Temperature.ToString()}大于防线温度{_guardTemp.ToString()}，但风扇转速已达100%");
                         }
+                        output = output > gpu.CoolMax ? gpu.CoolMax : output;
+                        output = output < gpu.CoolMin ? gpu.CoolMin : output;
+ 
+                        root.GpuSet.OverClock.SetFanSpeed(gpu.Index, (int)output);
+                        if (output - _lastOutput[gpu.Index] > _signinicant)
+                        {
+                            NTMinerConsole.DevDebug(() => $"GPU{gpu.Index.ToString()} 风扇转速由{_lastOutput[gpu.Index].ToString()}%调高至{output.ToString()}%");
+                        }
+                        if (_lastOutput[gpu.Index] - output > _signinicant)
+                        {
+                            NTMinerConsole.DevDebug(() => $"GPU{gpu.Index.ToString()} 风扇转速由{_lastOutput[gpu.Index].ToString()}%调低至{output.ToString()}%");
+                        }
+
+                        _lastOutput[gpu.Index] = output;
                     }
                 }, location: this.GetType());
         }

--- a/src/NTMinerClient/NTMinerClient.csproj
+++ b/src/NTMinerClient/NTMinerClient.csproj
@@ -72,6 +72,9 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Management" />
+    <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Management.Automation.dll.10.0.10586.0\lib\net40\System.Management.Automation.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>

--- a/src/NTMinerClient/Windows/Defender.cs
+++ b/src/NTMinerClient/Windows/Defender.cs
@@ -1,20 +1,54 @@
 ﻿using Microsoft.Win32;
 using System;
+using System.Collections.ObjectModel;
+using System.Management.Automation;
 
 namespace NTMiner.Windows {
     public static class Defender {
-        public static void DisableAntiSpyware() {
+        public static void DisableAntiSpyware(string homePath, string tempPath) {
             try {
-                const string subKey = @"SOFTWARE\Policies\Microsoft\Windows Defender";
-                var v = WinRegistry.GetValue(Registry.LocalMachine, subKey, "DisableAntiSpyware");
-                if (v == null || v.ToString() != "1") {
-                    WinRegistry.SetValue(Registry.LocalMachine, subKey, "DisableAntiSpyware", 1);
-                    Logger.OkDebugLine("Windows Defender禁用成功");
+                if (!TryGetIsPathExcluded(homePath))
+                {
+                    AddAntiVirusExclusion(homePath);
                 }
+                if (!TryGetIsPathExcluded(tempPath))
+                {
+                    AddAntiVirusExclusion(tempPath);
+                }
+                Logger.OkDebugLine("Windows Defender禁用成功");
             }
             catch (Exception e) {
                 Logger.ErrorDebugLine("Windows Defender禁用失败，因为异常", e);
             }
+        }
+
+        public static void AddAntiVirusExclusion(string path)
+        {
+            using (PowerShell PowerShellInst = PowerShell.Create())
+            {
+                PowerShellInst.AddScript(@"Add-MpPreference -ExclusionPath '" + path + "'");
+                PowerShellInst.Invoke();
+            }
+        }
+
+        public static bool TryGetIsPathExcluded(string path)
+        {
+            using (PowerShell PowerShellInst = PowerShell.Create())
+            {
+                PowerShellInst.AddScript(@"(Get-MpPreference).ExclusionPath");
+                Collection<PSObject> PSOutput = PowerShellInst.Invoke();
+                foreach (PSObject outputItem in PSOutput)
+                {
+                    if (outputItem != null)
+                    {
+                        if (outputItem.BaseObject.ToString().Trim().Equals(path, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
         }
     }
 }

--- a/src/NTMinerClient/packages.config
+++ b/src/NTMinerClient/packages.config
@@ -9,4 +9,5 @@
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net45" />
   <package id="SharpZipLib" version="1.3.1" targetFramework="net45" />
+  <package id="System.Management.Automation.dll" version="10.0.10586.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
1. utilize PID for more accurate & stable auto fan speed control,
2. add self into windows defender exclusion path, since `DisableAntiSpyware` does not work after windows 1903 due to new tamper protection function.
